### PR TITLE
xapi.js default config wrong path

### DIFF
--- a/src/main/resources/c-adapter/xapi/xapi.js
+++ b/src/main/resources/c-adapter/xapi/xapi.js
@@ -4,12 +4,12 @@ var xapiConfig = function () {
     if (this.xapiConfig != null) return this.xapiConfig;
     var xapiConfigFilePath = "etc/adapter.xapi.json";
     if (!fileExists(xapiConfigFilePath))
-        fileSave(xapiConfigFilePath, JSON.stringify({
+        fileSave(JSON.stringify({
             xapiEndpoint: "",
             xapiHostname: "",
             xapiAuth: "",
             enabled: false
-        }));
+        }),xapiConfigFilePath);
     this.xapiConfig = JSON.parse(fileToString(fileLoad(xapiConfigFilePath)));
     return this.xapiConfig;
 }


### PR DESCRIPTION
Exchanged parameters, first one is file content, second is file location

System produces error otherwise when starting because the file is not found:

`java.io.FileNotFoundException: File 'etc/adapter.xapi.json' does not exist
        at org.apache.commons.io.FileUtils.openInputStream(FileUtils.java:292)
        at org.apache.commons.io.FileUtils.readFileToByteArray(FileUtils.java:1815)
        at com.eduworks.util.io.InMemoryFile.<init>(InMemoryFile.java:24)
        at com.eduworks.cruncher.file.CruncherFileLoad.resolve(CruncherFileLoad.java:50)
        at jdk.nashorn.internal.scripts.Script$Recompilation$1829$80660AAA$\^eval\_.fileLoad(<eval>:805)
        at jdk.nashorn.internal.scripts.Script$Recompilation$1953$69$\^eval\_.xapiConfig(<eval>:13)
        at jdk.nashorn.internal.runtime.ScriptFunctionData.invoke(ScriptFunctionData.java:637)
        at jdk.nashorn.internal.runtime.ScriptFunction.invoke(ScriptFunction.java:494)
        at jdk.nashorn.internal.runtime.ScriptRuntime.apply(ScriptRuntime.java:393)
        at jdk.nashorn.api.scripting.ScriptObjectMirror.call(ScriptObjectMirror.java:117)
        at com.eduworks.resolver.CruncherJavascriptBinder.resolve(CruncherJavascriptBinder.java:72)
        at com.eduworks.levr.servlet.impl.LevrResolverServlet.execute(LevrResolverServlet.java:562)
        at com.eduworks.levr.servlet.impl.LevrResolverServlet$1.run(LevrResolverServlet.java:99)
        at com.eduworks.lang.threading.EwThreading$2.run(EwThreading.java:266)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
`