### PR TITLE
Update @xmldom/xmldom

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,8 @@
     "pure-uuid": "^1.6.2",
     "rdflib": "^2.2.20",
     "spdy": "^4.0.2",
-    "ws": "^8.9.0"
+    "ws": "^8.9.0",
+    "@xmldom/xmldom": "^0.8.4"
   },
   "devDependencies": {
     "chai": "^4.3.6",


### PR DESCRIPTION
CaSS currently uses @xmldom/xmldom 0.8.3, which parses XML that is not well-formed because it contains multiple top level elements, and adds all root nodes to the `childNodes` collection of the `Document`, without reporting any error or throwing. This breaks the assumption that there is only a single root node in the tree, which led to issuance of CVE-2022-39299 as it is a potential issue for dependents.

v 0.8.4 resolves this issue.

#issue - Description of changes optionally resulting in changed outcomes.

Security Impact: Description of security risks associated with these changes, if any.  
Presumptive Impact: Description of any assumptions that these changes make or enforce, if any.
