### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "cors": "^2.8.5",
     "cron": "^2.1.0",
     "express": "^4.18.2",
-    "express-jwt": "^7.7.7",
+    "express-jwt": "^8.2.1",
     "express-openid-connect": "^2.11.0",
     "express-ws": "^5.0.2",
     "http2": "^3.3.7",


### PR DESCRIPTION
express-jwt version 7 uses an insecure form of jsonwebtoken. Version 8 does not seem to break any CaSS features, and has the security issues fixed.

#issue - Description of changes optionally resulting in changed outcomes.

Security Impact: Description of security risks associated with these changes, if any.  
Presumptive Impact: Description of any assumptions that these changes make or enforce, if any.
