### PR TITLE
update luxon dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "http2": "^3.3.7",
     "http2-express-bridge": "^1.0.7",
     "jsonld": "^5.2.0",
+    "luxon":"^1.28.1",
     "node-object-hash": "^2.3.10",
     "node-worker-threads-pool": "^1.5.1",
     "nodemailer": "^6.8.0",


### PR DESCRIPTION
Currently CaSS uses Luxon 1.28.0 incrementing to 1.28.1 resolves an Insufficient Regular Expression Vulnerability.
source: https://github.com/advisories/GHSA-3xq5-wjfh-ppjc

#issue - Luxon's `DateTime.fromRFC2822() has quadratic (N^2) complexity on some specific inputs. This causes a noticeable slowdown for inputs with lengths above 10k characters. Users providing untrusted data to this method are therefore vulnerable to (Re)DoS attacks

Security Impact: Users providing untrusted data to this method are therefore vulnerable to (Re)DoS attacks.

Presumptive Impact:
