### PR TITLE
allow cors origin and cors credential to be controlled by env vars

### DIFF
--- a/src/main/server.js
+++ b/src/main/server.js
@@ -32,7 +32,25 @@ global.auditLogger = require('./server/shims/auditLogger.js');
 require("cassproject");
 const fs = require('fs');
 const cors = require('cors');
-app.use(cors());
+
+let corsOptions;
+if (process.env.CORS_ORIGINS != null || process.env.CORS_CREDENTIALS != null) {
+    corsOptions = {};
+
+    if (process.env.CORS_CREDENTIALS != null)
+        corsOptions.credentials = process.env.CORS_CREDENTIALS.trim() == 'true'
+    
+    if (process.env.CORS_ORIGINS != null) {
+        try {
+            corsOptions.origin = process.env.CORS_ORIGINS.split(',').map(x => x.trim());
+        } catch (e) {
+            global.auditLogger.report(global.auditLogger.LogCategory.SYSTEM, global.auditLogger.Severity.ERROR, "CorsConfigError", "Misconfigured CORS_ORIGINS env var, ensure the value is a comma separated list of origins");
+        }
+    }
+}
+
+app.use(cors(corsOptions));
+
 const envHttps = process.env.HTTPS != null ? process.env.HTTPS.trim() == 'true' : false;
 const port = process.env.PORT || (envHttps ? 443 : 80);
 

--- a/src/main/server/skyRepo.js
+++ b/src/main/server/skyRepo.js
@@ -9325,6 +9325,10 @@ var pingWithTime = function() {
     if (process.env.DEFAULT_PLUGINS) {
         (o).plugins = process.env.DEFAULT_PLUGINS;
     }
+    // Whether requests should include credentials
+    if (process.env.CORS_CREDENTIALS != null) {
+        (o)['corsCredentials'] = process.env.CORS_CREDENTIALS.trim() == 'true';
+    }
     return JSON.stringify(o);
 };
 (function() {


### PR DESCRIPTION
Adds support for 2 new environment variables, CORS_ORIGINS and CORS_CREDENTIALS

By default CaSS sets Access-Control-Allow-Origin to *, this would allow environment variables to control specific origins to allow.
Additionally allows Access-Control-Allow-Credentials to be set to true, allowing cookies to be used in cross domain requests, for example when trying to import frameworks from one cass server to another.

Security Impact: The environment variables are optional, if not present the behavior remains as it was before. Up to whoever is deploying CaSS to use these variables responsibly.