### PR TITLE
Platform One SSO Integration

### DIFF
--- a/src/main/server/shims/auth.js
+++ b/src/main/server/shims/auth.js
@@ -149,6 +149,11 @@ if (process.env.CASS_JWT_ENABLED)
 
 if (process.env.CASS_PLATFORM_ONE_AUTH_ENABLED)
 {
+    /**
+     * Extract the encoded JWT from the request's provided Authorization header.
+     * @param {String} authHeader 
+     * @returns 
+     */
     function parseHeader(authHeader) {
         if (!authHeader || !authHeader.startsWith("Bearer "))
             return null;
@@ -159,6 +164,11 @@ if (process.env.CASS_PLATFORM_ONE_AUTH_ENABLED)
         return parsed;
     }
     
+    /**
+     * Parse the JWT's body string into a JSON object.
+     * @param {String} tokenStr 
+     * @returns 
+     */
     function parseJwt (tokenStr) {
         let parts = tokenStr.split('.');
         let bodyEncodedB64 = parts[1];
@@ -168,6 +178,11 @@ if (process.env.CASS_PLATFORM_ONE_AUTH_ENABLED)
         return bodyDecoded;
     }
 
+    /**
+     * Validate whether this token has the expectd Platform One properties.
+     * @param {Object} token 
+     * @returns 
+     */
     function validateJwt (token) {
 
         let checkIssuer = process.env.CASS_PLATFORM_ONE_AUTH_CHECK_ISSUER;


### PR DESCRIPTION
Afternoon gang,

Submitting a PR to add a Platform One specific auth configuration to CaSS etc.

**Issue:** The existing JWT integration for CaSS requires that a secret or corresponding public key must be known to validate the JWT's authenticity.  As Platform One does not provide this, I have added an optional piece of auth middleware to handle their specific integration requirements.

**Security Impact:**
Unless this setting is enabled through an environment variable, then there is no functional change to CaSS.  If this setting is enabled, then there is an assumption that CaSS has been deployed behind Platform One's own security.

Additionally, this update does not add or modify any existing dependencies.

The only potential vulnerability would be if someone were to somehow enable this setting in a non-Platform One environment.

**Presumptive Impact:** The main presumption is that any CaSS instance using this auth workflow will be deployed within a Platform One environment.  