### PR TITLE
Anonymize P1 Users

### DIFF
--- a/src/main/server/shims/auth.js
+++ b/src/main/server/shims/auth.js
@@ -266,6 +266,10 @@ if (process.env.CASS_PLATFORM_ONE_AUTH_ENABLED)
                 return false;
         }
 
+        let uuid = token.sub;
+        if (typeof uuid !== "string" || uuid.length !== 36)
+            return false;
+
         return true;
     }
     

--- a/src/main/server/shims/auth.js
+++ b/src/main/server/shims/auth.js
@@ -193,7 +193,7 @@ if (process.env.CASS_PLATFORM_ONE_AUTH_ENABLED)
 
     /** @param {String} uuid */
     function numberFromUUID(uuid) {
-        let hex = Buffer.from(uuid).toString("hex", 16);
+        let hex = Buffer.from(uuid).toString("hex");
         return parseInt(hex, 16);
     }
 

--- a/src/main/server/shims/auth.js
+++ b/src/main/server/shims/auth.js
@@ -208,9 +208,9 @@ if (process.env.CASS_PLATFORM_ONE_AUTH_ENABLED)
         if (adjectives != null && adjectives.length > 0)
         {
             let uuidNumber = numberFromUUID(uuid);
-            let index = uuidNumber % providedAdjectives.length;
+            let index = uuidNumber % adjectives.length;
 
-            return providedAdjectives[index];
+            return adjectives[index];
         }
         
         return "Anonymous";
@@ -224,9 +224,9 @@ if (process.env.CASS_PLATFORM_ONE_AUTH_ENABLED)
         if (nouns != null && nouns.length > 0)
         {
             let uuidNumber = numberFromUUID(uuid);
-            let index = uuidNumber % providedNouns.length;
+            let index = uuidNumber % nouns.length;
 
-            return providedNouns[index];
+            return nouns[index];
         }
 
         return "User";


### PR DESCRIPTION
Small update to allow the P1 Auth shim to anonymize its users when creating the Person objects.

**Security Impact:** This update will shield Personally Identifiable Information from a user's corresponding Person object.  There are no vulnerabilities or dependency changes being introduced.  
**Presumptive Impact:** This update will only impact instances of CaSS using the P1 Auth shim who have also enabled the corresponding environment variables.  There will be no impact to other auth configurations.