### PR TITLE
Optional Support for Strict-Transport-Security Header

### DIFF
--- a/src/main/server.js
+++ b/src/main/server.js
@@ -127,6 +127,19 @@ if (process.env.DISABLED_EDITOR != 'true') {
     app.use(baseUrl+'cass-editor/', express.static('src/main/webapp/'));
 }
 
+if (process.env.INCLUDE_STRICT_TRANSPORT_SECURITY_HEADER == "true") {
+    app.use((req, res, next) => {
+
+        let forwardingProtocol = req.headers["x-forwarded-proto"];
+        let forwardedSecurely = forwardingProtocol && forwardingProtocol === "https"; 
+        if (forwardedSecurely || req.secure) {
+            res.setHeader("Strict-Transport-Security", "max-age=31536000")
+        }
+
+        next();
+    });
+}
+
 let v8 = require('v8');
 let glob = require('glob');
 let path = require('path');


### PR DESCRIPTION
Adding optional support of the `Strict-Transport-Security` header through an environment variable when using HTTPS.

**Security Impact**: No dependencies were introduced, nor were any potential vulnerabilities with the optional middleware.
**Presumptive Impact**: Enabling this variable will tell the user's browser to use HTTPS when contacting the configured instance of CaSS for the next year.  This will not impact any CaSS instance that does not specify the `INCLUDE_STRICT_TRANSPORT_SECURITY_HEADER` environment flag.
