### PR TITLE
Updating node-object-hash Import for Strict Mode Support

### DIFF
--- a/src/main/server/profile/worker.js
+++ b/src/main/server/profile/worker.js
@@ -46,7 +46,15 @@ if (!envHttp2)
     global.axios = require("axios"); //Pre-empt http2 use.
 }
 require("cassproject");
-global.hasher = require('node-object-hash');
+
+const hashModuleRoot = require("node-object-hash");
+
+// Newer versions of this library moved the function to a property
+//
+if (typeof hashModuleRoot !== "function")
+    global.hasher = hashModuleRoot.hasher;
+else
+    global.hasher = hashModuleRoot;
 
 const envHttps = process.env.HTTPS != null ? process.env.HTTPS.trim() == 'true' : false;
 


### PR DESCRIPTION
Updates the import syntax for the `node-object-hash` module, as builds with `--strict_mode` enabled would fail otherwise.

**Security Impact**: Allows the codebase to start with the `--strict_mode` flag.  
**Presumptive Impact**: There's an underlying assumption that the hashing module either has a function as its root import node (the earlier syntax) or has a single property named `hasher` (the newer syntax).  Ongoing updates to that repo may require updates to the import structure in the future, but this is always a possibility for major updates.
