### PR TITLE
adding x-frame-options header option

### DIFF
--- a/src/main/server.js
+++ b/src/main/server.js
@@ -129,7 +129,7 @@ if (process.env.DISABLED_EDITOR != 'true') {
 
 if (process.env.INCLUDE_SAMEORIGIN_IFRAME_HEADER == "true") {
     app.use((req, res, next) => {
-        res.setHeader("X-Frame-Options", "max-age=31536000")
+        res.setHeader("X-Frame-Options", "SAMEORIGIN")
         next();
     });
 }

--- a/src/main/server.js
+++ b/src/main/server.js
@@ -127,6 +127,13 @@ if (process.env.DISABLED_EDITOR != 'true') {
     app.use(baseUrl+'cass-editor/', express.static('src/main/webapp/'));
 }
 
+if (process.env.INCLUDE_SAMEORIGIN_IFRAME_HEADER == "true") {
+    app.use((req, res, next) => {
+        res.setHeader("X-Frame-Options", "max-age=31536000")
+        next();
+    });
+}
+
 if (process.env.INCLUDE_STRICT_TRANSPORT_SECURITY_HEADER == "true") {
     app.use((req, res, next) => {
 


### PR DESCRIPTION
Adding an optional `INCLUDE_SAMEORIGIN_IFRAME_HEADER` environment variable that will disable iframe embedding when not used within the same origin.  

**Security Impact**: Enabling this setting will prevent cross-domain iframe embedding of the system, a requirement for the SD Elements portion of CaSS' Platform One deployment.
**Presumptive Impact**: As this uses the same optional header approach as previous updates, this should have no impact for users who do not enable the header.  When enabled, browsers will prevent the CaSS application from being embedded within an iframe on cross-domain pages.
