### PR TITLE
Adding Optional Header to Prevent MIME Sniffing

### DIFF
--- a/src/main/server.js
+++ b/src/main/server.js
@@ -140,6 +140,13 @@ if (process.env.INCLUDE_STRICT_TRANSPORT_SECURITY_HEADER == "true") {
     });
 }
 
+if (process.env.INCLUDE_MIME_NOSNIFF_HEADER == "true") {
+    app.use((req, res, next) => {
+        res.setHeader("X-Content-Type-Options", "nosniff");
+        next();
+    });
+}
+
 let v8 = require('v8');
 let glob = require('glob');
 let path = require('path');


### PR DESCRIPTION
Adds an optional header to prevent MIME sniffing of content types when the environment variable `INCLUDE_MIME_NOSNIFF_HEADER` is provided and set to `"true"`.
```
X-Content-Type-Options: nosniff
```
**Security Impact**: Reduces the risk of type confusion.  Additionally, an attacker can carefully craft content to confuse the algorithm to perform unexpected operations, such as cross-site scripting and drive-by download.

**Presumptive Impact**: The update will not impact any CaSS instance that does not explicitly enable this setting.  Instances with this enabled will return the above header on their responses.
