### PR TITLE
Adding a Null Check for P1 Auth

### DIFF
--- a/src/main/server/shims/auth.js
+++ b/src/main/server/shims/auth.js
@@ -235,8 +235,8 @@ if (process.env.CASS_PLATFORM_ONE_AUTH_ENABLED)
      */
     function validateJwt (token) {
 
-		if (token == null)
-		    return false;
+        if (token == null)
+            return false;
 
         let checkIssuer = interpretEnvFlag(process.env.CASS_PLATFORM_ONE_AUTH_CHECK_ISSUER);
         if (checkIssuer) {

--- a/src/main/server/shims/auth.js
+++ b/src/main/server/shims/auth.js
@@ -235,6 +235,9 @@ if (process.env.CASS_PLATFORM_ONE_AUTH_ENABLED)
      */
     function validateJwt (token) {
 
+		if (token == null)
+		    return false;
+
         let checkIssuer = interpretEnvFlag(process.env.CASS_PLATFORM_ONE_AUTH_CHECK_ISSUER);
         if (checkIssuer) {
             let expectedIssuer = process.env.CASS_PLATFORM_ONE_ISSUER;


### PR DESCRIPTION
Since CaSS communicates with itself internally without carrying the auth header, the P1 middleware will receive an unexpected null for its JWT, causing an invalid state for the user it attempts to create.

This just adds a check to ensure that a null auth header is invalid before the actual JWT checks happen etc.

Security Impact: No security impact.
Presumptive Impact: Only enables CaSS to create a P1 user, whereas this wasn't possible before.
