### PR TITLE
Check for undefined

### DIFF
--- a/src/main/server/adapter/ceasn/ceasn.js
+++ b/src/main/server/adapter/ceasn/ceasn.js
@@ -31,7 +31,7 @@ let UUID = require('pure-uuid');
 
 
 async function ceasnExportUriTransform(uri, frameworkUri) {
-    if (ceasnExportUriPrefix == null)
+    if (ceasnExportUriPrefix == null || !uri)
         return uri;
     if (uri.startsWith(ceasnExportUriPrefix))
         return uri;


### PR DESCRIPTION
#1328 - Check for undefined uri before access when exporting framework to Credential Engine ASN (JSON-LD) to avoid error.
