### PR TITLE
CVE Updates for nodemailer and pm2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cass",
-  "version": "1.5.40",
+  "version": "1.5.42",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cass",
-      "version": "1.5.40",
+      "version": "1.5.42",
       "license": "Apache-2.0",
       "dependencies": {
         "@xmldom/xmldom": "^0.8.10",
@@ -21,8 +21,8 @@
         "express-ws": "^5.0.2",
         "node-object-hash": "^2.3.10",
         "node-worker-threads-pool": "^1.5.1",
-        "nodemailer": "^6.9.7",
-        "pm2": "^5.3.0",
+        "nodemailer": "^6.9.9",
+        "pm2": "^5.3.1",
         "pure-uuid": "^1.8.1",
         "rdflib": "^2.2.32",
         "spdy": "^4.0.2",
@@ -1091,14 +1091,14 @@
       "integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg=="
     },
     "node_modules/@pm2/js-api": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/@pm2/js-api/-/js-api-0.6.7.tgz",
-      "integrity": "sha512-jiJUhbdsK+5C4zhPZNnyA3wRI01dEc6a2GhcQ9qI38DyIk+S+C8iC3fGjcjUbt/viLYKPjlAaE+hcT2/JMQPXw==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@pm2/js-api/-/js-api-0.8.0.tgz",
+      "integrity": "sha512-nmWzrA/BQZik3VBz+npRcNIu01kdBhWL0mxKmP1ciF/gTcujPTQqt027N9fc1pK9ERM8RipFhymw7RcmCyOEYA==",
       "dependencies": {
         "async": "^2.6.3",
-        "axios": "^0.21.0",
         "debug": "~4.3.1",
         "eventemitter2": "^6.3.1",
+        "extrareqp2": "^1.0.0",
         "ws": "^7.0.0"
       },
       "engines": {
@@ -1645,11 +1645,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+      "dev": true,
       "dependencies": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.15.4",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -3765,6 +3768,14 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
+    "node_modules/extrareqp2": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/extrareqp2/-/extrareqp2-1.0.0.tgz",
+      "integrity": "sha512-Gum0g1QYb6wpPJCVypWP3bbIuaibcFiJcpuPM10YSXp/tzqi84x9PJageob+eN4xVRIOto4wjSGNLyMD54D2xA==",
+      "dependencies": {
+        "follow-redirects": "^1.14.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3932,9 +3943,9 @@
       "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ=="
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
       "funding": [
         {
           "type": "individual",
@@ -6158,9 +6169,9 @@
       "integrity": "sha512-7TXAhpMm+jO4MfESxYLtMGSnJWv+itdNHMdaFmeZuPXxwFGU90mtEB42BciUULXOUAxYBfXILAuvrSG3rQZ7mw=="
     },
     "node_modules/nodemailer": {
-      "version": "6.9.7",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.7.tgz",
-      "integrity": "sha512-rUtR77ksqex/eZRLmQ21LKVH5nAAsVicAtAYudK7JgwenEDZ0UIQ1adUGqErz7sMkWYxWTTU1aeP2Jga6WQyJw==",
+      "version": "6.9.9",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.9.tgz",
+      "integrity": "sha512-dexTll8zqQoVJEZPwQAKzxxtFn0qTnjdQTchoU6Re9BUUGBJiOy3YMn/0ShTW6J5M0dfQ1NeDeRTTl4oIWgQMA==",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -7258,13 +7269,13 @@
       }
     },
     "node_modules/pm2": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/pm2/-/pm2-5.3.0.tgz",
-      "integrity": "sha512-xscmQiAAf6ArVmKhjKTeeN8+Td7ZKnuZFFPw1DGkdFPR/0Iyx+m+1+OpCdf9+HQopX3VPc9/wqPQHqVOfHum9w==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/pm2/-/pm2-5.3.1.tgz",
+      "integrity": "sha512-DLVQHpSR1EegaTaRH3KbRXxpPVaqYwAp3uHSCtCsS++LSErvk07WSxuUnntFblBRqNU/w2KQyqs12mSq5wurkg==",
       "dependencies": {
         "@pm2/agent": "~2.0.0",
         "@pm2/io": "~5.0.0",
-        "@pm2/js-api": "~0.6.7",
+        "@pm2/js-api": "~0.8.0",
         "@pm2/pm2-version-check": "latest",
         "async": "~3.2.0",
         "blessed": "0.1.81",
@@ -9135,32 +9146,22 @@
       }
     },
     "node_modules/wait-on": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.0.1.tgz",
-      "integrity": "sha512-9AnJE9qTjRQOlTZIldAaf/da2eW0eSRSgcqq85mXQja/DW3MriHxkpODDSUEg+Gri/rKEcXUZHe+cevvYItaog==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.2.0.tgz",
+      "integrity": "sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==",
       "dev": true,
       "dependencies": {
-        "axios": "^0.27.2",
-        "joi": "^17.7.0",
+        "axios": "^1.6.1",
+        "joi": "^17.11.0",
         "lodash": "^4.17.21",
-        "minimist": "^1.2.7",
-        "rxjs": "^7.8.0"
+        "minimist": "^1.2.8",
+        "rxjs": "^7.8.1"
       },
       "bin": {
         "wait-on": "bin/wait-on"
       },
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "node_modules/wait-on/node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-      "dev": true,
-      "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
       }
     },
     "node_modules/wbuf": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cass",
-  "version": "1.5.40",
+  "version": "1.5.42",
   "description": "Competency and Skills System",
   "main": "src/main/server.js",
   "directories": {
@@ -100,8 +100,8 @@
     "express-ws": "^5.0.2",
     "node-object-hash": "^2.3.10",
     "node-worker-threads-pool": "^1.5.1",
-    "nodemailer": "^6.9.7",
-    "pm2": "^5.3.0",
+    "nodemailer": "^6.9.9",
+    "pm2": "^5.3.1",
     "pure-uuid": "^1.8.1",
     "rdflib": "^2.2.32",
     "spdy": "^4.0.2",


### PR DESCRIPTION
#issue - Description of changes optionally resulting in changed outcomes.

Morning @Lomilar, small update request for two libraries that are being flagged atm.

Security Impact: Resolves dependency vulnerabilities for pm2 and nodemailer.
Presumptive Impact: None, these are minor patches to address fringe surfaces and assist with automated pipeline scanning.
