### PR TITLE
Adding JWT Awareness to UI Ping

### DIFF
--- a/src/main/server/skyRepo.js
+++ b/src/main/server/skyRepo.js
@@ -10071,6 +10071,7 @@ const pingWithTime = function () {
     return JSON.stringify({
         ping: 'pong',
         time: new Date().getTime(),
+        ssoViaP1: this.ctx.req.p1 ? true : null,
         ssoPublicKey: this.ctx.req.eim ? this.ctx.req.eim.ids[0].ppk.toPk().toPem() : undefined,
         ssoAdditionalPublicKeys: this.ctx.req.eim && this.ctx.req.eim.ids.length ? this.ctx.req.eim.ids.slice(1).map((identity) => identity.ppk.toPk().toPem()) : undefined,
         ssoLogin: this.ctx.req.oidc ? (process.env.CASS_OIDC_BASE_URL || 'http://localhost/') + 'api/login' : undefined,
@@ -10119,6 +10120,11 @@ const pingWithTime = function () {
  *                   required: true
  *                   description: The current number of milliseconds since the Unix epoch, for ensuring signature sheet signing can sign time-nonced signatures that will not be time-desynchronized with the server.
  *                   example: 1674857764808
+ *                 ssoViaP1:
+ *                   type: bool
+ *                   required: false
+ *                   description: A flag indicating that the user logged in through a Platform One JWT.
+ *                   example: true
  *                 ssoPublicKey:
  *                   type: string
  *                   required: false


### PR DESCRIPTION
#issue - Description of changes optionally resulting in changed outcomes.

Currently, the Platform One deployments are not able to use the User Management features of the CaSS editor, due to the CaSS editor removing these features when it detects a public key without OIDC configuration.

This change will allow the "pong" function to return whether its context included auth via the P1 JWT, which will nullify the OIDC components of that check.

The UI portion of this change is here: https://github.com/cassproject/cass-editor/pull/1345

**Security Impact:** None, as the SSO key would have already needed to pass the other middleware.
**Presumptive Impact:** This change assumes that the JWT parsing and public key generation are all working as intended.
