### PR TITLE
Adding User Admins to Ping Request from UI

### DIFF
--- a/src/main/server/shims/auth.js
+++ b/src/main/server/shims/auth.js
@@ -422,6 +422,9 @@ app.use(async function (req, res, next) {
 
                 signatureSheetObj.push(adminSignatureObj);
                 signatureSheet = JSON.stringify(signatureSheetObj);
+                
+                let userPublicKeyStr = signatureSheetObj[0]["@owner"];
+                sharedAdminCache.addPublicKeyToKnownAdmins(userPublicKeyStr);
             }
 
             //THIS IS NOT OK, THE KEY INTO THE CACHE SHOULD NOT BE THE SERVER NAME!!!!!!!!!!

--- a/src/main/server/shims/auth.js
+++ b/src/main/server/shims/auth.js
@@ -1,4 +1,6 @@
 const fs = require('fs');
+const sharedAdminCache = require("./shims/util/sharedAdminCache");
+
 let keyEim = null;
 
 let getPkCache = {};

--- a/src/main/server/shims/util/sharedAdminCache.js
+++ b/src/main/server/shims/util/sharedAdminCache.js
@@ -1,0 +1,22 @@
+const adminCache = [];
+
+module.exports = {
+
+    addPublicKeyToKnownAdmins: (pk) => {
+        
+        if (typeof pk != "string") {
+            global.auditLogger.report(global.auditLogger.LogCategory.AUTH, global.auditLogger.Severity.INFO, "CassAdminCacheEntry", `Invalid key: ${typeof pk} was not a string`);
+            return;
+        }
+        
+        if (adminCache.includes(pk)) {
+            return;
+        }
+
+        adminCache.push(pk);        
+    },
+    
+    getKnownUserAdminPks: () => {
+        return adminCache;
+    }
+};

--- a/src/main/server/skyRepo.js
+++ b/src/main/server/skyRepo.js
@@ -3,6 +3,8 @@ const EcRsaOaepAsync = require('cassproject/src/com/eduworks/ec/crypto/EcRsaOaep
 const EcEncryptedValue = require('cassproject/src/org/cassproject/ebac/repository/EcEncryptedValue');
 const EcRemoteLinkedData = require('cassproject/src/org/cassproject/schema/general/EcRemoteLinkedData');
 const fs = require('fs');
+const sharedAdminCache = require("./shims/util/sharedAdminCache");
+
 
 // RS2 shims
 const afterSave = function (o) {
@@ -10069,6 +10071,15 @@ const skyrepoAdminPk = global.skyrepoAdminPk = function () {
 const skyrepoAdminList = global.skyrepoAdminList = function () {
     const array = [];
     array.push(skyrepoAdminPk());
+    
+    let mayHaveUserAdmins = process.env.AUTH_ALLOW_ENV_ADMINS == "true";
+    if (mayHaveUserAdmins) {
+        let knownAdminPks = sharedAdminCache.getKnownUserAdminPks();
+        for (let userPk of knownAdminPks) {
+            array.push(userPk);
+        }
+    }
+
     return array;
 };
 /**


### PR DESCRIPTION
Morning team, adding a small update to provide the configured public admin keys to the ping API, so that the editor can behave properly when this is configured.

This is a sister PR for https://github.com/cassproject/cass-editor/pull/1363

**Issue**: Ping API does not currently include the public keys of users who are considered admins for the given CaSS instance.

**Security Impact**: Users configured as administrators through the environment variables will have admin controls within the CaSS Editor.
**Presumptive Impact**: Admin functionality will be available to those users in the UI, in addition to simply the API commands which were granted in the previous PR for this.
