### PR TITLE
bugfix/494 - issue with missing import on sharedAdminCache in skyRepo/admin.js

### DIFF
--- a/src/main/server/skyRepo/admin.js
+++ b/src/main/server/skyRepo/admin.js
@@ -18,6 +18,7 @@
  * --END_LICENSE--
  */
 const fs = require('fs');
+const sharedAdminCache = require('../shims/util/sharedAdminCache.js');
 
 if (process.env.INSECURE_SERVER_IS_ADMIN) {
     process.env.PROFILE_PPK = EcPpk.fromPem(keyFor("skyAdmin2")).toPem();

--- a/src/test/1.skyrepo.admin.test.js
+++ b/src/test/1.skyrepo.admin.test.js
@@ -25,5 +25,17 @@ if (process.env.NODEV == null)
             }
             assert.strictEqual(EcPpk.fromPem(fileToString(fileLoad('etc/skyAdmin2.pem'))).toPk().toPem(), skyrepoAdminPk(), 'skyrepoAdminPk should return the public key from the pem file');
         });
+
+        it('skyrepoAdminList does not throw when env admins are enabled', () => {
+            const prev = process.env.AUTH_ALLOW_ENV_ADMINS;
+            process.env.AUTH_ALLOW_ENV_ADMINS = 'true';
+            try {
+                const list = skyrepoAdminList();
+                assert.isArray(list, 'skyrepoAdminList() should return an array of admin public keys');
+            } finally {
+                if (prev === undefined) delete process.env.AUTH_ALLOW_ENV_ADMINS;
+                else process.env.AUTH_ALLOW_ENV_ADMINS = prev;
+            }
+        });
     });
 }


### PR DESCRIPTION
## Summary

Fixes #494 issue with missing import on sharedAdminCache in admin.js

## Changes

- added `require` on `src/main/server/shims/util/sharedAdminCache.js` in `src/main/server/skyRepo/admin.js`

## Security Impact

None, `global` not necessary, due to ECMAScript module initializing a singleton of the module anyway (https://262.ecma-international.org/14.0/index.html#sec-InnerModuleLinking)

## Breaking Changes

- [X] No breaking changes

## Testing

- [X] Existing tests pass (See mocha commands in README)
- [X] New tests added (if applicable)
- [X] Manually verified (describe below)

ran tests locally. patch is live on my evaluation instance.

## Checklist

- [X] Code follows the existing style and conventions
- [X] Self-reviewed for correctness and clarity
- [ ] OpenAPI specs updated (if endpoints were added or changed) - n/a
- [ ] Documentation updated (if user-facing behavior changed) - n/a
- [X] No credentials, secrets, or personal data included
