### PR TITLE
bugfix/500 - fix `get-stream` import fault

### DIFF
--- a/src/main/server/shims/levr.js
+++ b/src/main/server/shims/levr.js
@@ -1,7 +1,12 @@
 const fs = require('fs');
 const nodePath = require('path');
 const busboy = require('busboy');
-const getStream = require('get-stream');
+const _getStream = require('get-stream');
+const getStream = typeof _getStream === 'function'
+    ? _getStream
+    : (_getStream.default || _getStream.getStream);
+// exposed for regression tests; the shim is otherwise loaded only for its global side effects.
+module.exports.getStream = getStream;
 const dns = require('dns').promises;
 
 // LEVR shims

--- a/src/test/1.shims.levr.test.js
+++ b/src/test/1.shims.levr.test.js
@@ -1,0 +1,16 @@
+const chai = require('chai');
+require('cassproject');
+const { Readable } = require('stream');
+if (process.env.NODEV == null)
+{
+    const assert = chai.assert;
+
+    describe('shims/levr.js', function () {
+        it('exposes a getStream that reads a stream to a string', async () => {
+            const { getStream } = require('../main/server/shims/levr');
+            assert.typeOf(getStream, 'function', 'levr.js must expose a callable getStream');
+            const text = await getStream(Readable.from(['hello ', 'world']));
+            assert.strictEqual(text, 'hello world');
+        });
+    });
+}


### PR DESCRIPTION
## Summary

Fixes #500 - fix `get-stream` import fault, after upstream migrated from CommonJS to strict ESM.


## Changes

- rewrote import/require statement to be compatible with upstream ESM module.
- added export of `get-stream` module to allow for regression test

## Security Impact

None, resolves a DOS-attack vector though. Remote process crash was possible for authenticated users.

## Breaking Changes

- [X] No breaking changes

## Testing

<!-- Describe how you verified these changes work correctly. -->

- [X] Existing tests pass (See mocha commands in README)
- [X] New tests added (if applicable)
- [X] Manually verified (describe below)

ran tests locally, patch is live on my evaluation instance.

## Checklist

- [X] Code follows the existing style and conventions
- [X] Self-reviewed for correctness and clarity
- [ ] OpenAPI specs updated (if endpoints were added or changed) - n/a
- [ ] Documentation updated (if user-facing behavior changed) - n/a
- [X] No credentials, secrets, or personal data included
